### PR TITLE
allow snapshots monitor over ssh using socat, add .config symbols to configuration, simplify ssh setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ How to create a setup for linux kernel debugging using buildroot, qemu and gdb.
 # Part 1: Compile linux kernel and rootfs
 We are going to compile linux kernel and rootfs using buildroot.
 Buildroot supplies all the toolchain which needed for automate the process of compiling linux kernel and rootfs.
-Buildroot was created for creating linux embedded/minimal systmes.
-However, if your purpose is developing or debugging linux kernel its really good solution.
+Buildroot was created for creating linux embedded/minimal systems.
+However, if your purpose is developing or debugging the linux kernel its really good solution.
 
 First, Clone buildroot repository (latest version):
 
@@ -15,16 +15,22 @@ First, Clone buildroot repository (latest version):
 
 ## Config buildroot
 Now we need to configure buildroot in order to build every packages with debug symbols.
-We also will need to ssh to the vm, then we will include in our rootfs openssh.
+In order to be able to ssh to the vm we'll add the openssh package.
 
 4. make qemu_x86_64_defconfig // Generate buildroot default config
 5. make menuconfig
 
-* In Build options, toggle “build packages with debugging symbols”
-* In System configuration, untoggle "Run a getty (login prompt) after boot"
-* In System configuration, enter root password
-* In Target packages, Networking applications, toggle "openssh"
-* In Filesystem images, change to ext4 root filesystem
+
+| Option | Corresponding config symbols                                                                                             |
+| ------ | -------------------------------------------------------------------------------------------------------------------------|
+| In Build options, toggle “build packages with debugging symbols”          | `BR2_ENABLE_DEBUG`                                    |
+| In System configuration, untoggle "Run a getty (login prompt) after boot" | `BR2_TARGET_GENERIC_GETTY`                            |
+| In System configuration, enter root password                              | `BR2_TARGET_GENERIC_ROOT_PASSWD`                      |
+| In Target packages, Networking applications, toggle "openssh"             | `BR2_PACKAGE_OPENSSH`                                 |
+| In Filesystem images, change to ext4 root filesystem                      | `BR2_TARGET_ROOTFS_EXT2` & `BR2_TARGET_ROOTFS_EXT2_4` |
+
+> The path to the options may change between buildroot versions, if an option is missing validate the symbols
+> are set appropriately using `cat .config | grep <symbol>` from buildroot's folder 
 
 #### Notes: 
 If you want to tell buildroot to download and compile antoher version of linux kernel:
@@ -38,16 +44,18 @@ Before opening the menuconfig it will trigger buildroot to download linux kernel
 
 6. make linux-menuconfig
 
-* In “Kernel hacking”, toggle “Kernel debugging”
-* In “Kernel hacking”, toggle “Compile the kernel with debug info”
-* In “Kernel hacking”, toggle “Compile the kernel with frame pointers”
+| Option | Corresponding config symbols                                                                                             |
+| ------ | -------------------------------------------------------------------------------------------------------------------------|
+| In “Kernel hacking”, toggle “Kernel debugging”                                                            | `CONFIG_DEBUG_KERNEL` |
+| In “Kernel hacking/Compile-time checks and compiler options”, toggle “Compile the kernel with debug info” | `DEBUG_INFO`          |
+| In “Kernel hacking”, toggle “Compile the kernel with frame pointers”                                      | `FRAME_POINTER`       |
 
 ## Compile linux kernel and rootfs
 Now lets compile everything:
 
 7. make -j8
 
-Improtant files:
+Important files:
 
 * output/build/linux-<version> contains the downloaded kernel source code
 * output/images/bzImage is the compressed kernel image
@@ -56,51 +64,72 @@ Improtant files:
 
 # Part 2: Debugging linux kernel using qemu and gdb
 
-After we compiled linux kernel and rootfs we can debug it.
-Our emulator will be qemu because qemu is really lightweight emulator that can be easily conigured to run almost anything and qemu works fine with kvm which improves the performence.
+After we compiled the linux kernel and rootfs we can debug it.
+Our emulator will be qemu because qemu is a really lightweight emulator that can be easily configured to run almost anything and qemu works fine with kvm which improves the performance.
 
-First, we need to convert our raw rootfs to qemu format which will be later used for creating snapshot.
+8. First, we'll enable ssh connections by changing `sshd_config`
+```
+sudo -i
+cd /path/to/buildroot/output/images
+mkdir /mnt/dbg_kernel_fs
+mount rootfs.ext2 /mnt/dbg_kernel_fs
+echo "PermitRootLogin yes" >> /mnt/dbg_kernel_fs/etc/ssh/sshd_config
+umount /mnt/dbg_kernel_fs
+rmdir /mnt/dbg_kernel_fs
+exit
+```
 
-Note: rootfs.ext4 is just a symlink to rootfs.ext2
+Now we'll convert our raw rootfs to qemu format which will enable us to create snapshots later on.
 
-8. qemu-img convert -f raw -O qcow2 rootfs.ext2 rootfs.qcow2
+9. 
+```
+cd ./output/images
+qemu-img convert -f raw -O qcow2 rootfs.ext2 rootfs.qcow2
+```
+
+> Note: rootfs.ext4 is just a symlink to rootfs.ext2
 
 ## Launch the vm
-9. sudo qemu-system-x86_64 -enable-kvm -cpu host -s -kernel bzImage  -m 2048 -hda rootfs.qcow2 -append "root=/dev/sda rw nokaslr" -net nic,model=virtio -net user,hostfwd=tcp::5555-:22
 
-Lets explain our command:
-* -enable-kvm -> kvm is a virtualization solution for linux which use hardware virtualization extensions, we will use it in order to improve the vm performence
+Copy/Replace `start-qemu.sh` from this repo into buildroot/output/images.
+This shell script runs qemu with customized flags explained below:
+
+* -monitor unix:qemu-monitor-socket,server,nowait -> creates a socket file named `qemu-monitor-socket` to which we'll connect with socat for the qemu monitoring
+* -enable-kvm -> kvm is a virtualization solution for linux which use hardware virtualization extensions, we will use it in order to improve the vm performance
 * -cpu host -> use host cpu, we will use it in order to improve the vm performence
 * -s -> qemu will open a gdbserver on TCP port 1234
-* -kernel -> path to the compiled kernel image
-* -m -> amount of memory of the vm
+* -m 2048 -> amount of memory of the vm (2mb in our example)
 * -hda -> path to the root filesystem image in our case the rootfs 
 * -append -> send command line arguments to the linux kernel
 * -net nic,model=virtio -> connect a network interface
-* -net user,hostfwd=tcp::5555-:22 -> in order to use ssh we will forward tcp traffic from host port 5555 to guest port 22
+* -net user,hostfwd=tcp::5555-:22 -> forwards tcp traffic from host port 5555 to guest port 22
+which allows us to use ssh.
 
-## Setup ssh (nice to have)
-After launcing the vm you should see buildroot login the username is root and use the password which we configured earlier.
-**Add "PermitRootLogin yes" to /etc/ssh/sshd_config in order to enable root login using ssh.**
-Now you can open the terminal on the host and execute:
-ssh -p 5555 root@localhost
 
-## Take a snapshot
-We will switch to qemu console in order to take the snapshot. 
+Now we can launch our vm:
 
-10. press Ctrl+Alt+2
-11. savevm <snapshot_name>
+11. ./start-qemu.sh
 
-If you want to launch the vm from a snapshot:
+#### SSH to guest
+`ssh root@localhost -p 5555`
 
-12. sudo qemu-system-x86_64 -enable-kvm -cpu host -s -kernel bzImage  -m 2048 -hda rootfs.qcow2 -append "root=/dev/sda rw nokaslr" -net nic,model=virtio -net user,hostfwd=tcp::5555-:22 -loadvm <snapshot_name>
+
+## Snapshots
+In order to take snapshots we'll connect to the qemu monitor 
+11. socat stdio,echo=0,icanon=0 unix-connect:qemu-monitor-socket
+
+saving and loading snapshots can be done in the following manner respectively:
+
+* savevm <snapshot_name>
+
+* loadvm <snapshot_name>
 
 ## Start the debugging session
 Now we are going to attach to our vm and the debug the kernel, we will also use our symbols to the kernel. 
 
-13. cd output/build/linux-{version}
-14. gdb ./vmlinux
-15. target remote :1234
+12. cd output/build/linux-{version}
+13. gdb ./vmlinux
+14. target remote :1234
 
 And now you got a kernel debugging session. 
 

--- a/start-qemu.sh
+++ b/start-qemu.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+(
+BINARIES_DIR="${0%/*}/"
+cd ${BINARIES_DIR}
+
+if [ "${1}" = "serial-only" ]; then
+    EXTRA_ARGS='-nographic'
+else
+    EXTRA_ARGS='-serial stdio'
+fi
+
+export PATH="../host/bin:${PATH}"
+exec qemu-system-x86_64 -s -monitor unix:qemu-monitor-socket,server,nowait -enable-kvm -cpu host -m 2048 -M pc -kernel bzImage -hda rootfs.qcow2 -append "rootwait root=/dev/sda console=tty1 console=ttyS0rw nokaslr"  -net nic,model=virtio -net user,hostfwd=tcp::5555-:22  ${EXTRA_ARGS}
+)


### PR DESCRIPTION
I used this tutorial using an arch machine I've connected to using ssh.

* qemu & qemu monitor now run over stdio (this allows sending commands to qemu monitor without shortcuts over ssh)
* some options were removed from buildroot's menu. However, the symbols for the kernel configuration are more stable so I've added a column for each option's corresponding symbols this way if buildroot keeps changing in the future users can validate they have created the same configuration in the different menu.
* ssh setup was not possible due to disabling `run a getty` there was no way to connect to the machine. I've kept the options for simplicity and added command lines that simplify the process. 